### PR TITLE
Add more granularity for the `_beforeModuleRegistration` hook

### DIFF
--- a/src/ReflexInstaller.sol
+++ b/src/ReflexInstaller.sol
@@ -94,7 +94,7 @@ abstract contract ReflexInstaller is IReflexInstaller, ReflexModule {
                 revert ModuleExistent(moduleSettings_.moduleId);
 
             // Call pre-registration hook.
-            _beforeModuleRegistration(moduleSettings_, moduleAddress);
+            _beforeModuleRegistration(moduleSettings_, address(this), moduleAddress);
 
             // Register the module.
             _REFLEX_STORAGE().modules[moduleSettings_.moduleId] = moduleAddress;
@@ -133,7 +133,7 @@ abstract contract ReflexInstaller is IReflexInstaller, ReflexModule {
             ) revert ModuleTypeInvalid(moduleSettings_.moduleType);
 
             // Call pre-registration hook.
-            _beforeModuleRegistration(moduleSettings_, moduleAddress);
+            _beforeModuleRegistration(moduleSettings_, address(this), moduleAddress);
 
             // Register the module.
             _REFLEX_STORAGE().modules[moduleSettings_.moduleId] = moduleAddress;
@@ -159,10 +159,12 @@ abstract contract ReflexInstaller is IReflexInstaller, ReflexModule {
     /**
      * @notice Hook that is called before a module is registered.
      * @param moduleSettings_ Module settings.
+     * @param stateAddress_ Reflex state address.
      * @param moduleAddress_ Module address.
      */
     function _beforeModuleRegistration(
         IReflexModule.ModuleSettings memory moduleSettings_,
+        address stateAddress_,
         address moduleAddress_
     ) internal virtual {}
 }

--- a/test/mocks/MockReflexInstaller.sol
+++ b/test/mocks/MockReflexInstaller.sol
@@ -50,11 +50,15 @@ contract MockReflexInstaller is MockHarness, ReflexInstaller, MockReflexModule {
         n_ = _getCounter(_BEFORE_MODULE_REGISTRATION_COUNTER_SLOT);
     }
 
-    function _beforeModuleRegistration(IReflexModule.ModuleSettings memory x_, address y_) internal override {
+    function _beforeModuleRegistration(
+        IReflexModule.ModuleSettings memory x_,
+        address y_,
+        address z_
+    ) internal override {
         _increaseCounter(_BEFORE_MODULE_REGISTRATION_COUNTER_SLOT);
 
         // Force coverage to flag this branch as covered.
-        super._beforeModuleRegistration(x_, y_);
+        super._beforeModuleRegistration(x_, y_, z_);
     }
 
     function getInstallerEndpointCreationCodeCounter() public view returns (uint256 n_) {


### PR DESCRIPTION
pass in the address of the state contract in the hook so we can have a more granular differentiation within modules and state contracts.