### PR TITLE
Fix: update deployer naming in ReflexDispatcher

### DIFF
--- a/src/ReflexDispatcher.sol
+++ b/src/ReflexDispatcher.sol
@@ -13,7 +13,12 @@ import {ReflexState} from "./ReflexState.sol";
 /**
  * @title Reflex Dispatcher
  *
- * @dev Execution takes place within the Dispatcher's storage context.
+ * @dev Execution takes place within the Dispatchers' storage context.
+ *
+ * The `Dispatcher` will take a call from a trusted endpoint, lookup the associated module and `DELEGATECALL`
+ * to the module with the `endpoint address` appended to the calldata. The original calldata includes the
+ * original `msg.sender` appended to it.
+ *
  * @dev Non-upgradeable, extendable.
  */
 abstract contract ReflexDispatcher is IReflexDispatcher, ReflexState {

--- a/src/ReflexDispatcher.sol
+++ b/src/ReflexDispatcher.sol
@@ -13,12 +13,7 @@ import {ReflexState} from "./ReflexState.sol";
 /**
  * @title Reflex Dispatcher
  *
- * @dev Execution takes place within the Dispatchers' storage context.
- *
- * The `Dispatcher` will take a call from a trusted endpoint, lookup the associated module and `DELEGATECALL`
- * to the module with the `endpoint address` appended to the calldata. The original calldata includes the
- * original `msg.sender` appended to it.
- *
+ * @dev Execution takes place within the Dispatcher's storage context.
  * @dev Non-upgradeable, extendable.
  */
 abstract contract ReflexDispatcher is IReflexDispatcher, ReflexState {

--- a/src/ReflexEndpoint.sol
+++ b/src/ReflexEndpoint.sol
@@ -18,7 +18,7 @@ contract ReflexEndpoint is IReflexEndpoint {
     /**
      * @notice Address of the `Dispatcher`, the deployer of this contract.
      */
-    address public immutable DISPATCHER;
+    address internal immutable _DISPATCHER;
 
     // ===========
     // Constructor
@@ -26,7 +26,7 @@ contract ReflexEndpoint is IReflexEndpoint {
 
     constructor() {
         // Register the deployer to perform logic on calls originating from the deployer.
-        DISPATCHER = msg.sender;
+        _DISPATCHER = msg.sender;
     }
 
     // ================
@@ -40,7 +40,7 @@ contract ReflexEndpoint is IReflexEndpoint {
     // solhint-disable-next-line payable-fallback, no-complex-fallback
     fallback() external virtual {
         // It is not possible to access immutable variables from the assembly block.
-        address dispatcher = DISPATCHER;
+        address dispatcher = _DISPATCHER;
 
         // If the caller is the deployer, instead of re-enter - issue a log message.
         if (msg.sender == dispatcher) {

--- a/src/ReflexEndpoint.sol
+++ b/src/ReflexEndpoint.sol
@@ -25,6 +25,7 @@ contract ReflexEndpoint is IReflexEndpoint {
     // ===========
 
     constructor() {
+        // Register the deployer to perform logic on calls originating from the deployer.
         DISPATCHER = msg.sender;
     }
 
@@ -38,6 +39,7 @@ contract ReflexEndpoint is IReflexEndpoint {
      */
     // solhint-disable-next-line payable-fallback, no-complex-fallback
     fallback() external virtual {
+        // It is not possible to access immutable variables from the assembly block.
         address dispatcher = DISPATCHER;
 
         // If the caller is the deployer, instead of re-enter - issue a log message.

--- a/src/ReflexEndpoint.sol
+++ b/src/ReflexEndpoint.sol
@@ -16,16 +16,16 @@ contract ReflexEndpoint is IReflexEndpoint {
     // ==========
 
     /**
-     * @dev Deployer address.
+     * @notice Address of the `Dispatcher`, the deployer of this contract.
      */
-    address internal immutable _deployer;
+    address public immutable DISPATCHER;
 
     // ===========
     // Constructor
     // ===========
 
     constructor() {
-        _deployer = msg.sender;
+        DISPATCHER = msg.sender;
     }
 
     // ================
@@ -38,10 +38,10 @@ contract ReflexEndpoint is IReflexEndpoint {
      */
     // solhint-disable-next-line payable-fallback, no-complex-fallback
     fallback() external virtual {
-        address deployer_ = _deployer;
+        address dispatcher = DISPATCHER;
 
         // If the caller is the deployer, instead of re-enter - issue a log message.
-        if (msg.sender == deployer_) {
+        if (msg.sender == dispatcher) {
             // We take full control of memory because it will not return to Solidity code.
             // Calldata: [number of topics as uint8 (1 byte)][topic #i (32 bytes)]{0,4}[extra log data (N bytes)]
             assembly {
@@ -103,7 +103,7 @@ contract ReflexEndpoint is IReflexEndpoint {
                 // Call so that execution happens within the `Dispatcher` context.
                 // Out and outsize are 0 because we don't know the size yet.
                 // Calldata: [calldata (N bytes)][msg.sender (20 bytes)]
-                let result := call(gas(), deployer_, 0, 0, add(calldatasize(), 20), 0, 0)
+                let result := call(gas(), dispatcher, 0, 0, add(calldatasize(), 20), 0, 0)
 
                 // Copy the returned data into memory, starting at position `0`.
                 returndatacopy(0x00, 0x00, returndatasize())

--- a/src/ReflexModule.sol
+++ b/src/ReflexModule.sol
@@ -22,12 +22,12 @@ abstract contract ReflexModule is IReflexModule, ReflexState {
     /**
      * @dev Module id.
      */
-    uint32 internal immutable _moduleId;
+    uint32 internal immutable _MODULE_ID;
 
     /**
      * @dev Module type.
      */
-    uint16 internal immutable _moduleType;
+    uint16 internal immutable _MODULE_TYPE;
 
     // =========
     // Modifiers
@@ -106,8 +106,8 @@ abstract contract ReflexModule is IReflexModule, ReflexState {
         if (moduleSettings_.moduleType == 0 || moduleSettings_.moduleType > _MODULE_TYPE_INTERNAL)
             revert ModuleTypeInvalid();
 
-        _moduleId = moduleSettings_.moduleId;
-        _moduleType = moduleSettings_.moduleType;
+        _MODULE_ID = moduleSettings_.moduleId;
+        _MODULE_TYPE = moduleSettings_.moduleType;
     }
 
     // ============
@@ -118,21 +118,21 @@ abstract contract ReflexModule is IReflexModule, ReflexState {
      * @inheritdoc IReflexModule
      */
     function moduleId() public view virtual returns (uint32) {
-        return _moduleId;
+        return _MODULE_ID;
     }
 
     /**
      * @inheritdoc IReflexModule
      */
     function moduleType() public view virtual returns (uint16) {
-        return _moduleType;
+        return _MODULE_TYPE;
     }
 
     /**
      * @inheritdoc IReflexModule
      */
     function moduleSettings() public view virtual returns (ModuleSettings memory) {
-        return ModuleSettings({moduleId: _moduleId, moduleType: _moduleType});
+        return ModuleSettings({moduleId: _MODULE_ID, moduleType: _MODULE_TYPE});
     }
 
     // ================


### PR DESCRIPTION
Closes:
- #132 

I've decided to keep `_DISPATCHER` internal to avoid polluting the function selector namespace unnecessarily.

I've also updated the other immutables to match the `UPPERCASE` styleguide for immutables.

Please note that these changes will be breaking upstream but should be relatively easy to fix.