### PR TITLE
Fix: ReflexState -> ReflexStorage

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,19 +19,21 @@ A Solidity framework for upgradeable modularized applications.
 
 ## Table of Contents
 
-- [Table of Contents](#table-of-contents)
-- [Traits](#traits)
-- [Motivation](#motivation)
-- [Contracts](#contracts)
-- [Install](#install)
-- [Usage](#usage)
-  - [Install Commands](#install-commands)
-  - [Build Commands](#build-commands)
-  - [Test Commands](#test-commands)
-- [Safety](#safety)
-- [Contributing](#contributing)
-- [Acknowledgements](#acknowledgements)
-- [License](#license)
+- [Reflex](#reflex)
+  - [Table of Contents](#table-of-contents)
+  - [Traits](#traits)
+  - [Motivation](#motivation)
+  - [Contracts](#contracts)
+  - [Install](#install)
+  - [Usage](#usage)
+    - [Install Commands](#install-commands)
+    - [Build Commands](#build-commands)
+    - [Test Commands](#test-commands)
+  - [Safety](#safety)
+  - [Known limitations](#known-limitations)
+  - [Contributing](#contributing)
+  - [Acknowledgements](#acknowledgements)
+  - [License](#license)
 
 ## Traits
 
@@ -72,7 +74,7 @@ In React, you as a developer do need to concern yourself with the internals of R
 │   ├── IReflexEndpoint.sol
 │   ├── IReflexInstaller.sol
 │   ├── IReflexModule.sol
-│   └── IReflexState.sol
+│   └── IReflexStorage.sol
 ├── periphery
 │   ├── interfaces
 │   │   └── IReflexBatch.sol
@@ -82,7 +84,7 @@ In React, you as a developer do need to concern yourself with the internals of R
 ├── ReflexEndpoint.sol
 ├── ReflexInstaller.sol
 ├── ReflexModule.sol
-└── ReflexState.sol
+└── ReflexStorage.sol
 ```
 
 ```mermaid
@@ -90,9 +92,9 @@ graph TD
     subgraph Reflex [ ]
 
     ReflexInstaller --> ReflexModule
-    ReflexDispatcher --> ReflexState
-    ReflexModule --> ReflexState
-    ReflexState --> ReflexConstants
+    ReflexDispatcher --> ReflexStorage
+    ReflexModule --> ReflexStorage
+    ReflexStorage --> ReflexConstants
     end
 ```
 

--- a/reports/REENTRANCY_LAYOUT.md
+++ b/reports/REENTRANCY_LAYOUT.md
@@ -196,7 +196,7 @@
 
 ```
 
-**ReflexState**
+**ReflexStorage**
 
 ```json
 

--- a/reports/SLITHER_CHECKLIST.md
+++ b/reports/SLITHER_CHECKLIST.md
@@ -52,49 +52,49 @@ Impact: Informational
 Confidence: High
 
 - [ ] ID-5
+      [ReflexStorage.\_REFLEX_STORAGE()](../src/ReflexStorage.sol#L116-L120) uses assembly - [INLINE ASM](../src/ReflexStorage.sol#L117-L119)
+
+../src/ReflexStorage.sol#L116-L120
+
+- [ ] ID-6
       [ReflexBatch.performStaticCall(address,bytes)](../src/periphery/ReflexBatch.sol#L24-L32) uses assembly - [INLINE ASM](../src/periphery/ReflexBatch.sol#L29-L31)
 
 ../src/periphery/ReflexBatch.sol#L24-L32
 
-- [ ] ID-6
+- [ ] ID-7
       [ReflexModule.\_createEndpoint(uint32,uint16,address)](../src/ReflexModule.sol#L149-L194) uses assembly - [INLINE ASM](../src/ReflexModule.sol#L168-L178)
 
 ../src/ReflexModule.sol#L149-L194
 
-- [ ] ID-7
+- [ ] ID-8
       [ReflexModule.\_unpackEndpointAddress()](../src/ReflexModule.sol#L226-L231) uses assembly - [INLINE ASM](../src/ReflexModule.sol#L228-L230)
 
 ../src/ReflexModule.sol#L226-L231
 
-- [ ] ID-8
+- [ ] ID-9
       [ReflexBatch.\_performBatchAction(IReflexBatch.BatchAction,address)](../src/periphery/ReflexBatch.sol#L111-L168) uses assembly - [INLINE ASM](../src/periphery/ReflexBatch.sol#L118-L161)
 
 ../src/periphery/ReflexBatch.sol#L111-L168
 
-- [ ] ID-9
+- [ ] ID-10
       [ReflexModule.\_unpackTrailingParameters()](../src/ReflexModule.sol#L238-L249) uses assembly - [INLINE ASM](../src/ReflexModule.sol#L245-L248)
 
 ../src/ReflexModule.sol#L238-L249
 
-- [ ] ID-10
+- [ ] ID-11
       [ReflexModule.\_revertBytes(bytes)](../src/ReflexModule.sol#L255-L266) uses assembly - [INLINE ASM](../src/ReflexModule.sol#L256-L265)
 
 ../src/ReflexModule.sol#L255-L266
 
-- [ ] ID-11
+- [ ] ID-12
       [ReflexDispatcher.constructor(address,address)](../src/ReflexDispatcher.sol#L28-L75) uses assembly - [INLINE ASM](../src/ReflexDispatcher.sol#L53-L63)
 
 ../src/ReflexDispatcher.sol#L28-L75
 
-- [ ] ID-12
+- [ ] ID-13
       [ReflexModule.\_unpackMessageSender()](../src/ReflexModule.sol#L215-L220) uses assembly - [INLINE ASM](../src/ReflexModule.sol#L217-L219)
 
 ../src/ReflexModule.sol#L215-L220
-
-- [ ] ID-13
-      [ReflexState.\_REFLEX_STORAGE()](../src/ReflexState.sol#L115-L119) uses assembly - [INLINE ASM](../src/ReflexState.sol#L116-L118)
-
-../src/ReflexState.sol#L115-L119
 
 - [ ] ID-14
       [ReflexDispatcher.fallback()](../src/ReflexDispatcher.sol#L110-L189) uses assembly - [INLINE ASM](../src/ReflexDispatcher.sol#L113-L188)
@@ -137,62 +137,62 @@ Impact: Informational
 Confidence: High
 
 - [ ] ID-20
+      Pragma version[^0.8.13](../src/ReflexStorage.sol#L2) allows old versions
+
+../src/ReflexStorage.sol#L2
+
+- [ ] ID-21
       Pragma version[^0.8.13](../src/interfaces/IReflexModule.sol#L2) allows old versions
 
 ../src/interfaces/IReflexModule.sol#L2
 
-- [ ] ID-21
+- [ ] ID-22
       Pragma version[^0.8.13](../src/periphery/ReflexBatch.sol#L2) allows old versions
 
 ../src/periphery/ReflexBatch.sol#L2
 
-- [ ] ID-22
+- [ ] ID-23
       Pragma version[^0.8.13](../src/interfaces/IReflexDispatcher.sol#L2) allows old versions
 
 ../src/interfaces/IReflexDispatcher.sol#L2
 
-- [ ] ID-23
+- [ ] ID-24
       Pragma version[^0.8.13](../src/interfaces/IReflexEndpoint.sol#L2) allows old versions
 
 ../src/interfaces/IReflexEndpoint.sol#L2
 
-- [ ] ID-24
-      Pragma version[^0.8.13](../src/interfaces/IReflexState.sol#L2) allows old versions
-
-../src/interfaces/IReflexState.sol#L2
-
 - [ ] ID-25
+      Pragma version[^0.8.13](../src/interfaces/IReflexStorage.sol#L2) allows old versions
+
+../src/interfaces/IReflexStorage.sol#L2
+
+- [ ] ID-26
       Pragma version[^0.8.13](../src/interfaces/IReflexInstaller.sol#L2) allows old versions
 
 ../src/interfaces/IReflexInstaller.sol#L2
 
-- [ ] ID-26
+- [ ] ID-27
       Pragma version[^0.8.13](../src/ReflexEndpoint.sol#L2) allows old versions
 
 ../src/ReflexEndpoint.sol#L2
 
-- [ ] ID-27
+- [ ] ID-28
       Pragma version[^0.8.13](../src/periphery/interfaces/IReflexBatch.sol#L2) allows old versions
 
 ../src/periphery/interfaces/IReflexBatch.sol#L2
 
-- [ ] ID-28
+- [ ] ID-29
       Pragma version[^0.8.13](../src/ReflexConstants.sol#L2) allows old versions
 
 ../src/ReflexConstants.sol#L2
 
-- [ ] ID-29
+- [ ] ID-30
       Pragma version[^0.8.13](../src/ReflexModule.sol#L2) allows old versions
 
 ../src/ReflexModule.sol#L2
 
-- [ ] ID-30
-      solc-0.8.19 is not recommended for deployment
-
 - [ ] ID-31
-      Pragma version[^0.8.13](../src/ReflexState.sol#L2) allows old versions
-
-../src/ReflexState.sol#L2
+      solc-0.8.19 is not recommended for deployment
 
 - [ ] ID-32
       Pragma version[^0.8.13](../src/ReflexInstaller.sol#L2) allows old versions
@@ -230,9 +230,9 @@ Impact: Informational
 Confidence: High
 
 - [ ] ID-37
-      Function [ReflexState.\_REFLEX_STORAGE()](../src/ReflexState.sol#L115-L119) is not in mixedCase
+      Function [ReflexStorage.\_REFLEX_STORAGE()](../src/ReflexStorage.sol#L116-L120) is not in mixedCase
 
-../src/ReflexState.sol#L115-L119
+../src/ReflexStorage.sol#L116-L120
 
 ## similar-names
 
@@ -260,24 +260,24 @@ Impact: Informational
 Confidence: High
 
 - [ ] ID-40
-      [ReflexState.\_REFLEX_STORAGE_OWNER_SLOT](../src/ReflexState.sol#L37-L38) is never used in [ReflexBatch](../src/periphery/ReflexBatch.sol#L16-L169)
+      [ReflexStorage.\_REFLEX_STORAGE_ENDPOINTS_SLOT](../src/ReflexStorage.sol#L59-L60) is never used in [ReflexBatch](../src/periphery/ReflexBatch.sol#L16-L169)
 
-../src/ReflexState.sol#L37-L38
+../src/ReflexStorage.sol#L59-L60
 
 - [ ] ID-41
+      [ReflexStorage.\_REFLEX_STORAGE_PENDING_OWNER_SLOT](../src/ReflexStorage.sol#L45-L46) is never used in [ReflexBatch](../src/periphery/ReflexBatch.sol#L16-L169)
+
+../src/ReflexStorage.sol#L45-L46
+
+- [ ] ID-42
       [ReflexConstants.\_MODULE_ID_INSTALLER](../src/ReflexConstants.sol#L49) is never used in [ReflexInstaller](../src/ReflexInstaller.sol#L17-L170)
 
 ../src/ReflexConstants.sol#L49
 
-- [ ] ID-42
-      [ReflexState.\_REFLEX_STORAGE_ENDPOINTS_SLOT](../src/ReflexState.sol#L58-L59) is never used in [ReflexInstaller](../src/ReflexInstaller.sol#L17-L170)
-
-../src/ReflexState.sol#L58-L59
-
 - [ ] ID-43
-      [ReflexState.\_REFLEX_STORAGE_ENDPOINTS_SLOT](../src/ReflexState.sol#L58-L59) is never used in [ReflexDispatcher](../src/ReflexDispatcher.sol#L19-L204)
+      [ReflexStorage.\_REFLEX_STORAGE_OWNER_SLOT](../src/ReflexStorage.sol#L38-L39) is never used in [ReflexBatch](../src/periphery/ReflexBatch.sol#L16-L169)
 
-../src/ReflexState.sol#L58-L59
+../src/ReflexStorage.sol#L38-L39
 
 - [ ] ID-44
       [ReflexConstants.\_MODULE_TYPE_MULTI_ENDPOINT](../src/ReflexConstants.sol#L35) is never used in [ReflexDispatcher](../src/ReflexDispatcher.sol#L19-L204)
@@ -285,59 +285,59 @@ Confidence: High
 ../src/ReflexConstants.sol#L35
 
 - [ ] ID-45
-      [ReflexState.\_REFLEX_STORAGE_MODULES_SLOT](../src/ReflexState.sol#L51-L52) is never used in [ReflexInstaller](../src/ReflexInstaller.sol#L17-L170)
+      [ReflexStorage.\_REFLEX_STORAGE_OWNER_SLOT](../src/ReflexStorage.sol#L38-L39) is never used in [ReflexDispatcher](../src/ReflexDispatcher.sol#L19-L204)
 
-../src/ReflexState.sol#L51-L52
+../src/ReflexStorage.sol#L38-L39
 
 - [ ] ID-46
-      [ReflexState.\_REFLEX_STORAGE_PENDING_OWNER_SLOT](../src/ReflexState.sol#L44-L45) is never used in [ReflexInstaller](../src/ReflexInstaller.sol#L17-L170)
-
-../src/ReflexState.sol#L44-L45
-
-- [ ] ID-47
-      [ReflexState.\_REFLEX_STORAGE_REENTRANCY_STATUS_SLOT](../src/ReflexState.sol#L30-L31) is never used in [ReflexDispatcher](../src/ReflexDispatcher.sol#L19-L204)
-
-../src/ReflexState.sol#L30-L31
-
-- [ ] ID-48
-      [ReflexState.\_REFLEX_STORAGE_RELATIONS_SLOT](../src/ReflexState.sol#L65-L66) is never used in [ReflexInstaller](../src/ReflexInstaller.sol#L17-L170)
-
-../src/ReflexState.sol#L65-L66
-
-- [ ] ID-49
-      [ReflexState.\_REFLEX_STORAGE_OWNER_SLOT](../src/ReflexState.sol#L37-L38) is never used in [ReflexDispatcher](../src/ReflexDispatcher.sol#L19-L204)
-
-../src/ReflexState.sol#L37-L38
-
-- [ ] ID-50
       [ReflexConstants.\_MODULE_ID_INSTALLER](../src/ReflexConstants.sol#L49) is never used in [ReflexBatch](../src/periphery/ReflexBatch.sol#L16-L169)
 
 ../src/ReflexConstants.sol#L49
 
+- [ ] ID-47
+      [ReflexStorage.\_REFLEX_STORAGE_PENDING_OWNER_SLOT](../src/ReflexStorage.sol#L45-L46) is never used in [ReflexInstaller](../src/ReflexInstaller.sol#L17-L170)
+
+../src/ReflexStorage.sol#L45-L46
+
+- [ ] ID-48
+      [ReflexStorage.\_REFLEX_STORAGE_ENDPOINTS_SLOT](../src/ReflexStorage.sol#L59-L60) is never used in [ReflexInstaller](../src/ReflexInstaller.sol#L17-L170)
+
+../src/ReflexStorage.sol#L59-L60
+
+- [ ] ID-49
+      [ReflexStorage.\_REFLEX_STORAGE_MODULES_SLOT](../src/ReflexStorage.sol#L52-L53) is never used in [ReflexInstaller](../src/ReflexInstaller.sol#L17-L170)
+
+../src/ReflexStorage.sol#L52-L53
+
+- [ ] ID-50
+      [ReflexStorage.\_REFLEX_STORAGE_PENDING_OWNER_SLOT](../src/ReflexStorage.sol#L45-L46) is never used in [ReflexDispatcher](../src/ReflexDispatcher.sol#L19-L204)
+
+../src/ReflexStorage.sol#L45-L46
+
 - [ ] ID-51
-      [ReflexState.\_REFLEX_STORAGE_PENDING_OWNER_SLOT](../src/ReflexState.sol#L44-L45) is never used in [ReflexDispatcher](../src/ReflexDispatcher.sol#L19-L204)
-
-../src/ReflexState.sol#L44-L45
-
-- [ ] ID-52
-      [ReflexState.\_REFLEX_STORAGE_OWNER_SLOT](../src/ReflexState.sol#L37-L38) is never used in [ReflexInstaller](../src/ReflexInstaller.sol#L17-L170)
-
-../src/ReflexState.sol#L37-L38
-
-- [ ] ID-53
-      [ReflexState.\_REFLEX_STORAGE_PENDING_OWNER_SLOT](../src/ReflexState.sol#L44-L45) is never used in [ReflexBatch](../src/periphery/ReflexBatch.sol#L16-L169)
-
-../src/ReflexState.sol#L44-L45
-
-- [ ] ID-54
-      [ReflexState.\_REFLEX_STORAGE_ENDPOINTS_SLOT](../src/ReflexState.sol#L58-L59) is never used in [ReflexBatch](../src/periphery/ReflexBatch.sol#L16-L169)
-
-../src/ReflexState.sol#L58-L59
-
-- [ ] ID-55
       [ReflexConstants.\_MODULE_TYPE_INTERNAL](../src/ReflexConstants.sol#L40) is never used in [ReflexDispatcher](../src/ReflexDispatcher.sol#L19-L204)
 
 ../src/ReflexConstants.sol#L40
+
+- [ ] ID-52
+      [ReflexStorage.\_REFLEX_STORAGE_ENDPOINTS_SLOT](../src/ReflexStorage.sol#L59-L60) is never used in [ReflexDispatcher](../src/ReflexDispatcher.sol#L19-L204)
+
+../src/ReflexStorage.sol#L59-L60
+
+- [ ] ID-53
+      [ReflexStorage.\_REFLEX_STORAGE_RELATIONS_SLOT](../src/ReflexStorage.sol#L66-L67) is never used in [ReflexInstaller](../src/ReflexInstaller.sol#L17-L170)
+
+../src/ReflexStorage.sol#L66-L67
+
+- [ ] ID-54
+      [ReflexStorage.\_REFLEX_STORAGE_OWNER_SLOT](../src/ReflexStorage.sol#L38-L39) is never used in [ReflexInstaller](../src/ReflexInstaller.sol#L17-L170)
+
+../src/ReflexStorage.sol#L38-L39
+
+- [ ] ID-55
+      [ReflexStorage.\_REFLEX_STORAGE_REENTRANCY_STATUS_SLOT](../src/ReflexStorage.sol#L31-L32) is never used in [ReflexDispatcher](../src/ReflexDispatcher.sol#L19-L204)
+
+../src/ReflexStorage.sol#L31-L32
 
 - [ ] ID-56
       [ReflexConstants.\_REENTRANCY_GUARD_LOCKED](../src/ReflexConstants.sol#L21) is never used in [ReflexDispatcher](../src/ReflexDispatcher.sol#L19-L204)

--- a/scripts/reentrancy-check.sh
+++ b/scripts/reentrancy-check.sh
@@ -34,7 +34,7 @@ fi
 log $GREEN "Verifying reentrancy modifier overview from contracts"
 
 # Variables
-CONTRACTS="ReflexConstants ReflexDispatcher ReflexInstaller ReflexModule ReflexEndpoint ReflexState ReflexBatch"
+CONTRACTS="ReflexConstants ReflexDispatcher ReflexInstaller ReflexModule ReflexEndpoint ReflexStorage ReflexBatch"
 FILENAME=reports/REENTRANCY_LAYOUT.md
 TEMP_FILENAME=reports/REENTRANCY_LAYOUT.temp.md
 

--- a/scripts/reentrancy-generate.sh
+++ b/scripts/reentrancy-generate.sh
@@ -27,7 +27,7 @@ fi
 log $GREEN "Creating reentrancy modifier overview from contracts"
 
 # Variables
-CONTRACTS="ReflexConstants ReflexDispatcher ReflexInstaller ReflexModule ReflexEndpoint ReflexState ReflexBatch"
+CONTRACTS="ReflexConstants ReflexDispatcher ReflexInstaller ReflexModule ReflexEndpoint ReflexStorage ReflexBatch"
 FILENAME=reports/REENTRANCY_LAYOUT.md
 
 # Remove previous reentracy layout

--- a/src/ReflexDispatcher.sol
+++ b/src/ReflexDispatcher.sol
@@ -8,7 +8,7 @@ import {IReflexModule} from "./interfaces/IReflexModule.sol";
 
 // Sources
 import {ReflexEndpoint} from "./ReflexEndpoint.sol";
-import {ReflexState} from "./ReflexState.sol";
+import {ReflexStorage} from "./ReflexStorage.sol";
 
 /**
  * @title Reflex Dispatcher
@@ -16,7 +16,7 @@ import {ReflexState} from "./ReflexState.sol";
  * @dev Execution takes place within the Dispatcher's storage context.
  * @dev Non-upgradeable, extendable.
  */
-abstract contract ReflexDispatcher is IReflexDispatcher, ReflexState {
+abstract contract ReflexDispatcher is IReflexDispatcher, ReflexStorage {
     // ===========
     // Constructor
     // ===========

--- a/src/ReflexModule.sol
+++ b/src/ReflexModule.sol
@@ -6,7 +6,7 @@ import {IReflexModule} from "./interfaces/IReflexModule.sol";
 
 // Sources
 import {ReflexEndpoint} from "./ReflexEndpoint.sol";
-import {ReflexState} from "./ReflexState.sol";
+import {ReflexStorage} from "./ReflexStorage.sol";
 
 /**
  * @title Reflex Module
@@ -14,7 +14,7 @@ import {ReflexState} from "./ReflexState.sol";
  * @dev Execution takes place within the Dispatcher's storage context.
  * @dev Upgradeable, extendable.
  */
-abstract contract ReflexModule is IReflexModule, ReflexState {
+abstract contract ReflexModule is IReflexModule, ReflexStorage {
     // ==========
     // Immutables
     // ==========

--- a/src/ReflexStorage.sol
+++ b/src/ReflexStorage.sol
@@ -110,7 +110,7 @@ abstract contract ReflexStorage is IReflexStorage, ReflexConstants {
 
     /**
      * @dev Get the Reflex storage pointer.
-     * @return storage_ Pointer to the Reflex storage state.
+     * @return storage_ Pointer to the Reflex storage slot.
      */
     // solhint-disable-next-line func-name-mixedcase
     function _REFLEX_STORAGE() internal pure returns (ReflexStorageLayout storage storage_) {

--- a/src/ReflexStorage.sol
+++ b/src/ReflexStorage.sol
@@ -2,16 +2,16 @@
 pragma solidity ^0.8.13;
 
 // Interfaces
-import {IReflexState} from "./interfaces/IReflexState.sol";
+import {IReflexStorage} from "./interfaces/IReflexStorage.sol";
 
 // Sources
 import {ReflexConstants} from "./ReflexConstants.sol";
 
 /**
- * @title Reflex State
+ * @title Reflex Storage
  * @dev Append-only extendable.
  */
-abstract contract ReflexState is IReflexState, ReflexConstants {
+abstract contract ReflexStorage is IReflexStorage, ReflexConstants {
     // =========
     // Constants
     // =========
@@ -74,7 +74,7 @@ abstract contract ReflexState is IReflexState, ReflexConstants {
      * @dev Append-only extendable.
      */
     /// @custom:storage-location erc7201:reflex
-    struct ReflexStorage {
+    struct ReflexStorageLayout {
         /**
          * @dev Global reentrancy status tracker.
          */
@@ -113,7 +113,7 @@ abstract contract ReflexState is IReflexState, ReflexConstants {
      * @return storage_ Pointer to the Reflex storage state.
      */
     // solhint-disable-next-line func-name-mixedcase
-    function _REFLEX_STORAGE() internal pure returns (ReflexStorage storage storage_) {
+    function _REFLEX_STORAGE() internal pure returns (ReflexStorageLayout storage storage_) {
         assembly ("memory-safe") {
             storage_.slot := _REFLEX_STORAGE_SLOT
         }

--- a/src/interfaces/IReflexDispatcher.sol
+++ b/src/interfaces/IReflexDispatcher.sol
@@ -2,12 +2,12 @@
 pragma solidity ^0.8.13;
 
 // Interfaces
-import {IReflexState} from "./IReflexState.sol";
+import {IReflexStorage} from "./IReflexStorage.sol";
 
 /**
  * @title Reflex Dispatcher Interface
  */
-interface IReflexDispatcher is IReflexState {
+interface IReflexDispatcher is IReflexStorage {
     // ======
     // Errors
     // ======

--- a/src/interfaces/IReflexModule.sol
+++ b/src/interfaces/IReflexModule.sol
@@ -2,12 +2,12 @@
 pragma solidity ^0.8.13;
 
 // Interfaces
-import {IReflexState} from "./IReflexState.sol";
+import {IReflexStorage} from "./IReflexStorage.sol";
 
 /**
  * @title Reflex Module Interface
  */
-interface IReflexModule is IReflexState {
+interface IReflexModule is IReflexStorage {
     // ======
     // Errors
     // ======

--- a/src/interfaces/IReflexStorage.sol
+++ b/src/interfaces/IReflexStorage.sol
@@ -2,9 +2,9 @@
 pragma solidity ^0.8.13;
 
 /**
- * @title Reflex State Interface
+ * @title Reflex Storage Interface
  */
-interface IReflexState {
+interface IReflexStorage {
     // =======
     // Structs
     // =======

--- a/test/GasBenchmark.t.sol
+++ b/test/GasBenchmark.t.sol
@@ -11,7 +11,7 @@ import {ReflexConstants} from "../src/ReflexConstants.sol";
 import {ReflexModule} from "../src/ReflexModule.sol";
 
 // Mocks
-import {ImplementationState} from "./mocks/abstracts/ImplementationState.sol";
+import {ImplementationStorage} from "./mocks/abstracts/ImplementationStorage.sol";
 import {MockImplementationDispatcher} from "./mocks/MockImplementationDispatcher.sol";
 import {MockImplementationInstaller} from "./mocks/MockImplementationInstaller.sol";
 
@@ -197,7 +197,7 @@ contract GasBenchmarkTest is ReflexConstants {
 /**
  * @title Mock Implementation Gas Module
  */
-contract MockImplementationGasModule is ReflexModule, ImplementationState {
+contract MockImplementationGasModule is ReflexModule, ImplementationStorage {
     // =======
     // Storage
     // =======

--- a/test/ImplementationModuleInternal.t.sol
+++ b/test/ImplementationModuleInternal.t.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.13;
 // Interfaces
 import {IReflexInstaller} from "../src/interfaces/IReflexInstaller.sol";
 import {IReflexModule} from "../src/interfaces/IReflexModule.sol";
-import {IReflexState} from "../src/interfaces/IReflexState.sol";
+import {IReflexStorage} from "../src/interfaces/IReflexStorage.sol";
 
 // Fixtures
 import {ImplementationFixture} from "./fixtures/ImplementationFixture.sol";
@@ -89,7 +89,7 @@ contract ImplementationModuleInternalTest is ImplementationFixture {
     }
 
     function testUnitGetTrustRelation() external {
-        IReflexState.TrustRelation memory relation = dispatcher.getTrustRelation(address(internalModuleV1));
+        IReflexStorage.TrustRelation memory relation = dispatcher.getTrustRelation(address(internalModuleV1));
 
         assertEq(relation.moduleId, 0);
         assertEq(relation.moduleImplementation, address(0));
@@ -116,7 +116,7 @@ contract ImplementationModuleInternalTest is ImplementationFixture {
         bytes32 value = abi.decode(
             singleModuleEndpoint.callInternalModule(
                 _MODULE_INTERNAL_ID,
-                abi.encodeWithSignature("getImplementationState0()")
+                abi.encodeWithSignature("getImplementationStorage0()")
             ),
             (bytes32)
         );
@@ -125,13 +125,13 @@ contract ImplementationModuleInternalTest is ImplementationFixture {
 
         singleModuleEndpoint.callInternalModule(
             _MODULE_INTERNAL_ID,
-            abi.encodeWithSignature("setImplementationState0(bytes32)", message_)
+            abi.encodeWithSignature("setImplementationStorage0(bytes32)", message_)
         );
 
         value = abi.decode(
             singleModuleEndpoint.callInternalModule(
                 _MODULE_INTERNAL_ID,
-                abi.encodeWithSignature("getImplementationState0()")
+                abi.encodeWithSignature("getImplementationStorage0()")
             ),
             (bytes32)
         );
@@ -143,7 +143,7 @@ contract ImplementationModuleInternalTest is ImplementationFixture {
         vm.expectRevert();
         singleModuleEndpoint.callInternalModule(
             _MODULE_INTERNAL_ID,
-            abi.encodeWithSignature("getImplementationState777()")
+            abi.encodeWithSignature("getImplementationStorage777()")
         );
     }
 
@@ -152,7 +152,7 @@ contract ImplementationModuleInternalTest is ImplementationFixture {
 
         singleModuleEndpoint.callInternalModule(
             _MODULE_INTERNAL_ID,
-            abi.encodeWithSignature("setImplementationState0(bytes32)", message_)
+            abi.encodeWithSignature("setImplementationStorage0(bytes32)", message_)
         );
 
         // Verify internal module.
@@ -210,9 +210,9 @@ contract ImplementationModuleInternalTest is ImplementationFixture {
 
         // Initialize and verify the storage in the `Dispatcher` context.
 
-        dispatcher.setImplementationState0(messageA_);
+        dispatcher.setImplementationStorage0(messageA_);
 
-        assertEq(dispatcher.getImplementationState0(), messageA_);
+        assertEq(dispatcher.getImplementationStorage0(), messageA_);
 
         _verifyModuleConfiguration(
             IReflexModule.ModuleSettings({moduleId: _MODULE_INTERNAL_ID, moduleType: _MODULE_TYPE_INTERNAL})
@@ -245,7 +245,7 @@ contract ImplementationModuleInternalTest is ImplementationFixture {
 
         singleModuleEndpoint.callInternalModule(
             _MODULE_INTERNAL_ID,
-            abi.encodeWithSignature("setMaliciousImplementationState0(bytes32)", messageB_)
+            abi.encodeWithSignature("setMaliciousImplementationStorage0(bytes32)", messageB_)
         );
 
         // Verify storage has been modified by malicious upgrade in `Dispatcher` context.
@@ -254,7 +254,7 @@ contract ImplementationModuleInternalTest is ImplementationFixture {
             abi.decode(
                 singleModuleEndpoint.callInternalModule(
                     _MODULE_INTERNAL_ID,
-                    abi.encodeWithSignature("getMaliciousImplementationState0()")
+                    abi.encodeWithSignature("getMaliciousImplementationStorage0()")
                 ),
                 (bytes32)
             ),
@@ -263,21 +263,21 @@ contract ImplementationModuleInternalTest is ImplementationFixture {
 
         // Verify that the storage in the `Dispatcher` context has been overwritten, this is disastrous.
 
-        assertEq(dispatcher.getImplementationState0(), messageB_);
+        assertEq(dispatcher.getImplementationStorage0(), messageB_);
 
         // Overwrite storage in the `Dispatcher` context.
 
-        dispatcher.setImplementationState0(messageA_);
+        dispatcher.setImplementationStorage0(messageA_);
 
         // Verify that the storage in the `Dispatcher` context has been overwritten.
 
-        assertEq(dispatcher.getImplementationState0(), messageA_);
+        assertEq(dispatcher.getImplementationStorage0(), messageA_);
 
         assertEq(
             abi.decode(
                 singleModuleEndpoint.callInternalModule(
                     _MODULE_INTERNAL_ID,
-                    abi.encodeWithSignature("getMaliciousImplementationState0()")
+                    abi.encodeWithSignature("getMaliciousImplementationStorage0()")
                 ),
                 (bytes32)
             ),
@@ -300,24 +300,24 @@ contract ImplementationModuleInternalTest is ImplementationFixture {
     }
 
     function _verifyUnmodifiedStateSlots(bytes32 message_) internal {
-        assertEq(singleModuleV1.getImplementationState0(), 0);
-        assertEq(singleModuleV2.getImplementationState0(), 0);
-        assertEq(singleModuleEndpoint.getImplementationState0(), message_);
+        assertEq(singleModuleV1.getImplementationStorage0(), 0);
+        assertEq(singleModuleV2.getImplementationStorage0(), 0);
+        assertEq(singleModuleEndpoint.getImplementationStorage0(), message_);
 
-        assertEq(internalModuleV1.getImplementationState0(), 0);
-        assertEq(internalModuleV2.getImplementationState0(), 0);
-        assertEq(internalModuleV3.getImplementationState0(), 0);
+        assertEq(internalModuleV1.getImplementationStorage0(), 0);
+        assertEq(internalModuleV2.getImplementationStorage0(), 0);
+        assertEq(internalModuleV3.getImplementationStorage0(), 0);
 
         assertEq(
             abi.decode(
                 singleModuleEndpoint.callInternalModule(
                     _MODULE_INTERNAL_ID,
-                    abi.encodeWithSignature("getImplementationState0()")
+                    abi.encodeWithSignature("getImplementationStorage0()")
                 ),
                 (bytes32)
             ),
             message_
         );
-        assertEq(dispatcher.getImplementationState0(), message_);
+        assertEq(dispatcher.getImplementationStorage0(), message_);
     }
 }

--- a/test/ImplementationModuleInternal.t.sol
+++ b/test/ImplementationModuleInternal.t.sol
@@ -163,7 +163,7 @@ contract ImplementationModuleInternalTest is ImplementationFixture {
 
         // Verify storage is not modified by upgrades in `Dispatcher` context.
 
-        _verifyUnmodifiedStateSlots(message_);
+        _verifyUnmodifiedStorageSlots(message_);
 
         // Upgrade internal module.
 
@@ -177,7 +177,7 @@ contract ImplementationModuleInternalTest is ImplementationFixture {
 
         // Verify storage is not modified by upgrades in `Dispatcher` context.
 
-        _verifyUnmodifiedStateSlots(message_);
+        _verifyUnmodifiedStorageSlots(message_);
 
         // Upgrade single-endpoint module.
 
@@ -199,7 +199,7 @@ contract ImplementationModuleInternalTest is ImplementationFixture {
 
         // Verify storage is not modified by upgrades in `Dispatcher` context.
 
-        _verifyUnmodifiedStateSlots(message_);
+        _verifyUnmodifiedStorageSlots(message_);
     }
 
     function testFuzzUpgradeInternalModuleToMaliciousStorageModule(
@@ -299,7 +299,7 @@ contract ImplementationModuleInternalTest is ImplementationFixture {
         assertEq(moduleSettings.moduleType, moduleSettings_.moduleType);
     }
 
-    function _verifyUnmodifiedStateSlots(bytes32 message_) internal {
+    function _verifyUnmodifiedStorageSlots(bytes32 message_) internal {
         assertEq(singleModuleV1.getImplementationStorage0(), 0);
         assertEq(singleModuleV2.getImplementationStorage0(), 0);
         assertEq(singleModuleEndpoint.getImplementationStorage0(), message_);

--- a/test/ImplementationModuleMultiEndpoint.t.sol
+++ b/test/ImplementationModuleMultiEndpoint.t.sol
@@ -200,7 +200,7 @@ contract ImplementationModuleMultiEndpointTest is ImplementationFixture {
 
         // Verify storage is not modified by upgrades in `Dispatcher` context.
 
-        _verifyUnmodifiedStateSlots(message_);
+        _verifyUnmodifiedStorageSlots(message_);
 
         // Upgrade single-endpoint module.
 
@@ -212,7 +212,7 @@ contract ImplementationModuleMultiEndpointTest is ImplementationFixture {
 
         // Verify storage is not modified by upgrades in `Dispatcher` context.
 
-        _verifyUnmodifiedStateSlots(message_);
+        _verifyUnmodifiedStorageSlots(message_);
 
         // Upgrade the upgraded multi-endpoint module.
 
@@ -226,7 +226,7 @@ contract ImplementationModuleMultiEndpointTest is ImplementationFixture {
 
         // Verify storage is not modified by upgrades in `Dispatcher` context.
 
-        _verifyUnmodifiedStateSlots(message_);
+        _verifyUnmodifiedStorageSlots(message_);
     }
 
     function testFuzzUpgradeMultiModuleToMaliciousStorageModule(
@@ -416,7 +416,7 @@ contract ImplementationModuleMultiEndpointTest is ImplementationFixture {
     // Utilities
     // =========
 
-    function _verifyUnmodifiedStateSlots(bytes32 message_) internal {
+    function _verifyUnmodifiedStorageSlots(bytes32 message_) internal {
         assertEq(singleModuleV1.getImplementationStorage0(), 0);
         assertEq(singleModuleV2.getImplementationStorage0(), 0);
         assertEq(singleModuleEndpoint.getImplementationStorage0(), message_);

--- a/test/ImplementationModuleMultiEndpoint.t.sol
+++ b/test/ImplementationModuleMultiEndpoint.t.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.13;
 import {IReflexEndpoint} from "../src/interfaces/IReflexEndpoint.sol";
 import {IReflexInstaller} from "../src/interfaces/IReflexInstaller.sol";
 import {IReflexModule} from "../src/interfaces/IReflexModule.sol";
-import {IReflexState} from "../src/interfaces/IReflexState.sol";
+import {IReflexStorage} from "../src/interfaces/IReflexStorage.sol";
 
 // Fixtures
 import {ImplementationFixture} from "./fixtures/ImplementationFixture.sol";
@@ -138,9 +138,9 @@ contract ImplementationModuleMultiEndpointTest is ImplementationFixture {
     }
 
     function testUnitGetTrustRelation() external {
-        IReflexState.TrustRelation memory relationA = dispatcher.getTrustRelation(address(multiModuleEndpointA));
-        IReflexState.TrustRelation memory relationB = dispatcher.getTrustRelation(address(multiModuleEndpointB));
-        IReflexState.TrustRelation memory relationC = dispatcher.getTrustRelation(address(multiModuleEndpointC));
+        IReflexStorage.TrustRelation memory relationA = dispatcher.getTrustRelation(address(multiModuleEndpointA));
+        IReflexStorage.TrustRelation memory relationB = dispatcher.getTrustRelation(address(multiModuleEndpointB));
+        IReflexStorage.TrustRelation memory relationC = dispatcher.getTrustRelation(address(multiModuleEndpointC));
 
         assertEq(relationA.moduleId, _MODULE_ID_MULTI);
         assertEq(relationB.moduleId, _MODULE_ID_MULTI);
@@ -180,7 +180,7 @@ contract ImplementationModuleMultiEndpointTest is ImplementationFixture {
     function testFuzzUpgradeMultiEndpoint(bytes32 message_) external brutalizeMemory {
         // Initialize the storage in the `Dispatcher` context.
 
-        dispatcher.setImplementationState0(message_);
+        dispatcher.setImplementationStorage0(message_);
 
         // Verify multi-endpoint module.
 
@@ -237,9 +237,9 @@ contract ImplementationModuleMultiEndpointTest is ImplementationFixture {
 
         // Initialize and verify the storage in the `Dispatcher` context.
 
-        dispatcher.setImplementationState0(messageA_);
+        dispatcher.setImplementationStorage0(messageA_);
 
-        assertEq(dispatcher.getImplementationState0(), messageA_);
+        assertEq(dispatcher.getImplementationStorage0(), messageA_);
 
         // Upgrade multi-endpoint module to malicious storage module.
 
@@ -273,47 +273,53 @@ contract ImplementationModuleMultiEndpointTest is ImplementationFixture {
 
         // Overwrite storage in the `Dispatcher` context from the malicious module.
 
-        MockImplementationMaliciousStorageModule(address(multiModuleEndpointA)).setMaliciousImplementationState0(
+        MockImplementationMaliciousStorageModule(address(multiModuleEndpointA)).setMaliciousImplementationStorage0(
             messageB_
         );
 
         // Verify storage has been modified by malicious upgrade in `Dispatcher` context.
 
         assertEq(
-            MockImplementationMaliciousStorageModule(address(multiModuleEndpointA)).getMaliciousImplementationState0(),
+            MockImplementationMaliciousStorageModule(address(multiModuleEndpointA))
+                .getMaliciousImplementationStorage0(),
             messageB_
         );
         assertEq(
-            MockImplementationMaliciousStorageModule(address(multiModuleEndpointB)).getMaliciousImplementationState0(),
+            MockImplementationMaliciousStorageModule(address(multiModuleEndpointB))
+                .getMaliciousImplementationStorage0(),
             messageB_
         );
         assertEq(
-            MockImplementationMaliciousStorageModule(address(multiModuleEndpointC)).getMaliciousImplementationState0(),
+            MockImplementationMaliciousStorageModule(address(multiModuleEndpointC))
+                .getMaliciousImplementationStorage0(),
             messageB_
         );
 
         // Verify that the storage in the `Dispatcher` context has been overwritten, this is disastrous.
 
-        assertEq(dispatcher.getImplementationState0(), messageB_);
+        assertEq(dispatcher.getImplementationStorage0(), messageB_);
 
         // Overwrite storage in the `Dispatcher` context.
 
-        dispatcher.setImplementationState0(messageA_);
+        dispatcher.setImplementationStorage0(messageA_);
 
         // Verify that the storage in the `Dispatcher` context has been overwritten.
 
-        assertEq(dispatcher.getImplementationState0(), messageA_);
+        assertEq(dispatcher.getImplementationStorage0(), messageA_);
 
         assertEq(
-            MockImplementationMaliciousStorageModule(address(multiModuleEndpointA)).getMaliciousImplementationState0(),
+            MockImplementationMaliciousStorageModule(address(multiModuleEndpointA))
+                .getMaliciousImplementationStorage0(),
             messageA_
         );
         assertEq(
-            MockImplementationMaliciousStorageModule(address(multiModuleEndpointB)).getMaliciousImplementationState0(),
+            MockImplementationMaliciousStorageModule(address(multiModuleEndpointB))
+                .getMaliciousImplementationStorage0(),
             messageA_
         );
         assertEq(
-            MockImplementationMaliciousStorageModule(address(multiModuleEndpointC)).getMaliciousImplementationState0(),
+            MockImplementationMaliciousStorageModule(address(multiModuleEndpointC))
+                .getMaliciousImplementationStorage0(),
             messageA_
         );
     }
@@ -411,18 +417,18 @@ contract ImplementationModuleMultiEndpointTest is ImplementationFixture {
     // =========
 
     function _verifyUnmodifiedStateSlots(bytes32 message_) internal {
-        assertEq(singleModuleV1.getImplementationState0(), 0);
-        assertEq(singleModuleV2.getImplementationState0(), 0);
-        assertEq(singleModuleEndpoint.getImplementationState0(), message_);
+        assertEq(singleModuleV1.getImplementationStorage0(), 0);
+        assertEq(singleModuleV2.getImplementationStorage0(), 0);
+        assertEq(singleModuleEndpoint.getImplementationStorage0(), message_);
 
-        assertEq(multiModuleV1.getImplementationState0(), 0);
-        assertEq(multiModuleV2.getImplementationState0(), 0);
-        assertEq(multiModuleV3.getImplementationState0(), 0);
+        assertEq(multiModuleV1.getImplementationStorage0(), 0);
+        assertEq(multiModuleV2.getImplementationStorage0(), 0);
+        assertEq(multiModuleV3.getImplementationStorage0(), 0);
 
-        assertEq(multiModuleEndpointA.getImplementationState0(), message_);
-        assertEq(multiModuleEndpointB.getImplementationState0(), message_);
-        assertEq(multiModuleEndpointC.getImplementationState0(), message_);
+        assertEq(multiModuleEndpointA.getImplementationStorage0(), message_);
+        assertEq(multiModuleEndpointB.getImplementationStorage0(), message_);
+        assertEq(multiModuleEndpointC.getImplementationStorage0(), message_);
 
-        assertEq(dispatcher.getImplementationState0(), message_);
+        assertEq(dispatcher.getImplementationStorage0(), message_);
     }
 }

--- a/test/ImplementationModuleSingleEndpoint.t.sol
+++ b/test/ImplementationModuleSingleEndpoint.t.sol
@@ -117,7 +117,7 @@ contract ImplementationModuleSingleEndpointTest is ImplementationFixture {
 
         // Verify storage is not modified by upgrades in `Dispatcher` context.
 
-        _verifyUnmodifiedStateSlots(message_);
+        _verifyUnmodifiedStorageSlots(message_);
 
         // Upgrade the upgraded single-endpoint module.
 
@@ -129,7 +129,7 @@ contract ImplementationModuleSingleEndpointTest is ImplementationFixture {
 
         // Verify storage is not modified by upgrades in `Dispatcher` context.
 
-        _verifyUnmodifiedStateSlots(message_);
+        _verifyUnmodifiedStorageSlots(message_);
     }
 
     function testFuzzUpgradeSingleModuleToMaliciousStorageModule(
@@ -261,7 +261,7 @@ contract ImplementationModuleSingleEndpointTest is ImplementationFixture {
     // Utilities
     // =========
 
-    function _verifyUnmodifiedStateSlots(bytes32 message_) internal {
+    function _verifyUnmodifiedStorageSlots(bytes32 message_) internal {
         assertEq((singleModuleV1).getImplementationStorage0(), 0);
         assertEq((singleModuleV2).getImplementationStorage0(), 0);
         assertEq(singleModuleEndpoint.getImplementationStorage0(), message_);

--- a/test/ImplementationModuleSingleEndpoint.t.sol
+++ b/test/ImplementationModuleSingleEndpoint.t.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.13;
 import {IReflexEndpoint} from "../src/interfaces/IReflexEndpoint.sol";
 import {IReflexInstaller} from "../src/interfaces/IReflexInstaller.sol";
 import {IReflexModule} from "../src/interfaces/IReflexModule.sol";
-import {IReflexState} from "../src/interfaces/IReflexState.sol";
+import {IReflexStorage} from "../src/interfaces/IReflexStorage.sol";
 
 // Fixtures
 import {ImplementationFixture} from "./fixtures/ImplementationFixture.sol";
@@ -78,7 +78,7 @@ contract ImplementationModuleSingleEndpointTest is ImplementationFixture {
     }
 
     function testUnitGetTrustRelation() external {
-        IReflexState.TrustRelation memory relation = dispatcher.getTrustRelation(address(singleModuleEndpoint));
+        IReflexStorage.TrustRelation memory relation = dispatcher.getTrustRelation(address(singleModuleEndpoint));
 
         assertEq(relation.moduleId, _MODULE_ID_SINGLE);
         assertEq(relation.moduleImplementation, address(singleModuleV1));
@@ -101,7 +101,7 @@ contract ImplementationModuleSingleEndpointTest is ImplementationFixture {
     function testFuzzUpgradeSingleEndpoint(bytes32 message_) external brutalizeMemory {
         // Initialize the storage in the `Dispatcher` context.
 
-        dispatcher.setImplementationState0(message_);
+        dispatcher.setImplementationStorage0(message_);
 
         // Verify single-endpoint module.
 
@@ -142,9 +142,9 @@ contract ImplementationModuleSingleEndpointTest is ImplementationFixture {
 
         // Initialize and verify the storage in the `Dispatcher` context.
 
-        dispatcher.setImplementationState0(messageA_);
+        dispatcher.setImplementationStorage0(messageA_);
 
-        assertEq(dispatcher.getImplementationState0(), messageA_);
+        assertEq(dispatcher.getImplementationStorage0(), messageA_);
 
         _verifyModuleConfiguration(singleModuleEndpoint, _MODULE_ID_SINGLE, _MODULE_TYPE_SINGLE_ENDPOINT);
 
@@ -166,31 +166,33 @@ contract ImplementationModuleSingleEndpointTest is ImplementationFixture {
 
         // Overwrite storage in the `Dispatcher` context from the malicious module.
 
-        MockImplementationMaliciousStorageModule(address(singleModuleEndpoint)).setMaliciousImplementationState0(
+        MockImplementationMaliciousStorageModule(address(singleModuleEndpoint)).setMaliciousImplementationStorage0(
             messageB_
         );
 
         // Verify storage has been modified by malicious upgrade in `Dispatcher` context.
 
         assertEq(
-            MockImplementationMaliciousStorageModule(address(singleModuleEndpoint)).getMaliciousImplementationState0(),
+            MockImplementationMaliciousStorageModule(address(singleModuleEndpoint))
+                .getMaliciousImplementationStorage0(),
             messageB_
         );
 
         // Verify that the storage in the `Dispatcher` context has been overwritten, this is disastrous.
 
-        assertEq(dispatcher.getImplementationState0(), messageB_);
+        assertEq(dispatcher.getImplementationStorage0(), messageB_);
 
         // Overwrite storage in the `Dispatcher` context.
 
-        dispatcher.setImplementationState0(messageA_);
+        dispatcher.setImplementationStorage0(messageA_);
 
         // Verify that the storage in the `Dispatcher` context has been overwritten.
 
-        assertEq(dispatcher.getImplementationState0(), messageA_);
+        assertEq(dispatcher.getImplementationStorage0(), messageA_);
 
         assertEq(
-            MockImplementationMaliciousStorageModule(address(singleModuleEndpoint)).getMaliciousImplementationState0(),
+            MockImplementationMaliciousStorageModule(address(singleModuleEndpoint))
+                .getMaliciousImplementationStorage0(),
             messageA_
         );
     }
@@ -260,9 +262,9 @@ contract ImplementationModuleSingleEndpointTest is ImplementationFixture {
     // =========
 
     function _verifyUnmodifiedStateSlots(bytes32 message_) internal {
-        assertEq((singleModuleV1).getImplementationState0(), 0);
-        assertEq((singleModuleV2).getImplementationState0(), 0);
-        assertEq(singleModuleEndpoint.getImplementationState0(), message_);
-        assertEq(dispatcher.getImplementationState0(), message_);
+        assertEq((singleModuleV1).getImplementationStorage0(), 0);
+        assertEq((singleModuleV2).getImplementationStorage0(), 0);
+        assertEq(singleModuleEndpoint.getImplementationStorage0(), message_);
+        assertEq(dispatcher.getImplementationStorage0(), message_);
     }
 }

--- a/test/ImplementationStorage.t.sol
+++ b/test/ImplementationStorage.t.sol
@@ -16,7 +16,7 @@ import {MockImplementationModule} from "./mocks/MockImplementationModule.sol";
 /**
  * @title Implementation State Test
  */
-contract ImplementationStateTest is ImplementationFixture {
+contract ImplementationStorageTest is ImplementationFixture {
     // =========
     // Constants
     // =========
@@ -65,36 +65,36 @@ contract ImplementationStateTest is ImplementationFixture {
         bytes32 current;
 
         /**
-         * | Name                           | Type    | Slot                   | Offset | Bytes |
-         * |--------------------------------|---------|------------------------|--------|-------|
-         * | ReflexStorage.reentrancyStatus | address | RELEX_STORAGE_SLOT + 0 | 0      | 32    |
+         * | Name                                 | Type    | Slot                   | Offset | Bytes |
+         * |--------------------------------------|---------|------------------------|--------|-------|
+         * | ReflexStorageLayout.reentrancyStatus | address | RELEX_STORAGE_SLOT + 0 | 0      | 32    |
          */
         vm.record();
-        dispatcher.getReflexState0();
+        dispatcher.getReflexStorage0();
         (reads, ) = vm.accesses(address(dispatcher));
         assertEq(uint256(reads[0]), uint256(REFLEX_STORAGE_SLOT) + 0);
         current = vm.load(address(dispatcher), bytes32(reads[0]));
         assertEq(uint256(current), 1);
 
         /**
-         * | Name                | Type    | Slot                   | Offset | Bytes |
-         * |---------------------|---------|------------------------|--------|-------|
-         * | ReflexStorage.owner | address | RELEX_STORAGE_SLOT + 1 | 0      | 32    |
+         * | Name                      | Type    | Slot                   | Offset | Bytes |
+         * |---------------------------|---------|------------------------|--------|-------|
+         * | ReflexStorageLayout.owner | address | RELEX_STORAGE_SLOT + 1 | 0      | 32    |
          */
         vm.record();
-        dispatcher.getReflexState1();
+        dispatcher.getReflexStorage1();
         (reads, ) = vm.accesses(address(dispatcher));
         assertEq(uint256(reads[0]), uint256(REFLEX_STORAGE_SLOT) + 1);
         current = vm.load(address(dispatcher), bytes32(reads[0]));
         assertEq(address(uint160(uint256(current))), address(this));
 
         /**
-         * | Name                       | Type    | Slot                   | Offset | Bytes |
-         * |----------------------------|---------|------------------------|--------|-------|
-         * | ReflexStorage.pendingOwner | address | RELEX_STORAGE_SLOT + 2 | 0      | 32    |
+         * | Name                             | Type    | Slot                   | Offset | Bytes |
+         * |----------------------------------|---------|------------------------|--------|-------|
+         * | ReflexStorageLayout.pendingOwner | address | RELEX_STORAGE_SLOT + 2 | 0      | 32    |
          */
         vm.record();
-        dispatcher.getReflexState2();
+        dispatcher.getReflexStorage2();
         (reads, ) = vm.accesses(address(dispatcher));
         assertEq(uint256(reads[0]), uint256(REFLEX_STORAGE_SLOT) + 2);
         current = vm.load(address(dispatcher), bytes32(reads[0]));
@@ -103,43 +103,43 @@ contract ImplementationStateTest is ImplementationFixture {
         installerEndpoint.transferOwnership(address(target_));
 
         vm.record();
-        dispatcher.getReflexState2();
+        dispatcher.getReflexStorage2();
         (reads, ) = vm.accesses(address(dispatcher));
         assertEq(uint256(reads[0]), uint256(REFLEX_STORAGE_SLOT) + 2);
         current = vm.load(address(dispatcher), bytes32(reads[0]));
         assertEq(address(uint160(uint256(current))), address(target_));
 
         /**
-         * | Name                | Type    | Slot                    | Offset | Bytes |
-         * |---------------------|---------|-------------------------|--------|-------|
-         * | ReflexState.modules | address | REFLEX_STORAGE_SLOT + 3 | 0      | 32    |
+         * | Name                        | Type    | Slot                    | Offset | Bytes |
+         * |-----------------------------|---------|-------------------------|--------|-------|
+         * | ReflexStorageLayout.modules | address | REFLEX_STORAGE_SLOT + 3 | 0      | 32    |
          */
         vm.record();
-        dispatcher.getReflexState3(_MODULE_ID_SINGLE);
+        dispatcher.getReflexStorage3(_MODULE_ID_SINGLE);
         (reads, ) = vm.accesses(address(dispatcher));
         assertEq((reads[0]), keccak256(abi.encode(_MODULE_ID_SINGLE, uint256(REFLEX_STORAGE_SLOT) + 3)));
         current = vm.load(address(dispatcher), bytes32(reads[0]));
         assertEq(address(uint160(uint256(current))), address(singleModuleImplementation));
 
         /**
-         * | Name                  | Type    | Slot                    | Offset | Bytes |
-         * |-----------------------|---------|-------------------------|--------|-------|
-         * | ReflexState.endpoints | address | REFLEX_STORAGE_SLOT + 4 | 0      | 32    |
+         * | Name                          | Type    | Slot                    | Offset | Bytes |
+         * |-------------------------------|---------|-------------------------|--------|-------|
+         * | ReflexStorageLayout.endpoints | address | REFLEX_STORAGE_SLOT + 4 | 0      | 32    |
          */
         vm.record();
-        dispatcher.getReflexState4(_MODULE_ID_SINGLE);
+        dispatcher.getReflexStorage4(_MODULE_ID_SINGLE);
         (reads, ) = vm.accesses(address(dispatcher));
         assertEq((reads[0]), keccak256(abi.encode(_MODULE_ID_SINGLE, uint256(REFLEX_STORAGE_SLOT) + 4)));
         current = vm.load(address(dispatcher), bytes32(reads[0]));
         assertEq(address(uint160(uint256(current))), address(singleModuleEndpoint));
 
         /**
-         * | Name                  | Type    | Slot                    | Offset | Bytes |
-         * |-----------------------|---------|-------------------------|--------|-------|
-         * | ReflexState.relations | address | REFLEX_STORAGE_SLOT + 5 | 0      | 32    |
+         * | Name                          | Type    | Slot                    | Offset | Bytes |
+         * |-------------------------------|---------|-------------------------|--------|-------|
+         * | ReflexStorageLayout.relations | address | REFLEX_STORAGE_SLOT + 5 | 0      | 32    |
          */
         vm.record();
-        dispatcher.getReflexState5(address(singleModuleEndpoint));
+        dispatcher.getReflexStorage5(address(singleModuleEndpoint));
         (reads, ) = vm.accesses(address(dispatcher));
         assertEq((reads[0]), keccak256(abi.encode(address(singleModuleEndpoint), uint256(REFLEX_STORAGE_SLOT) + 5)));
         current = vm.load(address(dispatcher), bytes32(reads[0]));
@@ -160,85 +160,85 @@ contract ImplementationStateTest is ImplementationFixture {
         bytes32[] memory reads;
         bytes32 current;
 
-        // Set implementation state.
-        installerEndpoint.setImplementationState(message_, number_, target_, flag_, tokenA_, tokenB_);
+        // Set implementation storage.
+        installerEndpoint.setImplementationStorage(message_, number_, target_, flag_, tokenA_, tokenB_);
 
         /**
-         * | Name                                     | Type    | Slot                            | Offset | Bytes |
-         * |------------------------------------------|---------|---------------------------------|--------|-------|
-         * | ImplementationState.implementationState0 | address | IMPLEMENTATION_STORAGE_SLOT + 0 | 0      | 32    |
+         * | Name                                         | Type    | Slot                            | Offset | Bytes |
+         * |----------------------------------------------|---------|---------------------------------|--------|-------|
+         * | ImplementationStorage.implementationStorage0 | address | IMPLEMENTATION_STORAGE_SLOT + 0 | 0      | 32    |
          */
         vm.record();
-        dispatcher.getImplementationState0();
+        dispatcher.getImplementationStorage0();
         (reads, ) = vm.accesses(address(dispatcher));
         assertEq(uint256(reads[0]), uint256(IMPLEMENTATION_STORAGE_SLOT) + 0);
         current = vm.load(address(dispatcher), bytes32(reads[0]));
         assertEq(current, message_);
 
         /**
-         * | Name                                     | Type    | Slot                            | Offset | Bytes |
-         * |------------------------------------------|---------|---------------------------------|--------|-------|
-         * | ImplementationState.implementationState1 | address | IMPLEMENTATION_STORAGE_SLOT + 1 | 0      | 32    |
+         * | Name                                         | Type    | Slot                            | Offset | Bytes |
+         * |----------------------------------------------|---------|---------------------------------|--------|-------|
+         * | ImplementationStorage.implementationStorage1 | address | IMPLEMENTATION_STORAGE_SLOT + 1 | 0      | 32    |
          */
         vm.record();
-        dispatcher.getImplementationState1();
+        dispatcher.getImplementationStorage1();
         (reads, ) = vm.accesses(address(dispatcher));
         assertEq(uint256(reads[0]), uint256(IMPLEMENTATION_STORAGE_SLOT) + 1);
         current = vm.load(address(dispatcher), bytes32(reads[0]));
         assertEq(uint256(current), number_);
 
         /**
-         * | Name                                     | Type    | Slot                            | Offset | Bytes |
-         * |------------------------------------------|---------|---------------------------------|--------|-------|
-         * | ImplementationState.implementationState2 | address | IMPLEMENTATION_STORAGE_SLOT + 2 | 0      | 20    |
+         * | Name                                         | Type    | Slot                            | Offset | Bytes |
+         * |----------------------------------------------|---------|---------------------------------|--------|-------|
+         * | ImplementationStorage.implementationStorage2 | address | IMPLEMENTATION_STORAGE_SLOT + 2 | 0      | 20    |
          */
         vm.record();
-        dispatcher.getImplementationState2();
+        dispatcher.getImplementationStorage2();
         (reads, ) = vm.accesses(address(dispatcher));
         assertEq(uint256(reads[0]), uint256(IMPLEMENTATION_STORAGE_SLOT) + 2);
         current = vm.load(address(dispatcher), bytes32(reads[0]));
         assertEq(address(uint160(uint256(current))), target_);
 
         /**
-         * | Name                                     | Type    | Slot                            | Offset | Bytes |
-         * |------------------------------------------|---------|---------------------------------|--------|-------|
-         * | ImplementationState.implementationState3 | address | IMPLEMENTATION_STORAGE_SLOT + 3 | 0      | 20    |
+         * | Name                                         | Type    | Slot                            | Offset | Bytes |
+         * |----------------------------------------------|---------|---------------------------------|--------|-------|
+         * | ImplementationStorage.implementationStorage3 | address | IMPLEMENTATION_STORAGE_SLOT + 3 | 0      | 20    |
          */
         vm.record();
-        dispatcher.getImplementationState3();
+        dispatcher.getImplementationStorage3();
         (reads, ) = vm.accesses(address(dispatcher));
         assertEq(uint256(reads[0]), uint256(IMPLEMENTATION_STORAGE_SLOT) + 3);
         current = vm.load(address(dispatcher), bytes32(reads[0]));
         assertEq(address(uint160(uint256(current))), target_);
 
         /**
-         * | Name                                     | Type    | Slot                            | Offset | Bytes |
-         * |------------------------------------------|---------|---------------------------------|--------|-------|
-         * | ImplementationState.implementationState4 | address | IMPLEMENTATION_STORAGE_SLOT + 3 | 0      | 1     |
+         * | Name                                         | Type    | Slot                            | Offset | Bytes |
+         * |----------------------------------------------|---------|---------------------------------|--------|-------|
+         * | ImplementationStorage.implementationStorage4 | address | IMPLEMENTATION_STORAGE_SLOT + 3 | 0      | 1     |
          */
         vm.record();
-        dispatcher.getImplementationState4();
+        dispatcher.getImplementationStorage4();
         (reads, ) = vm.accesses(address(dispatcher));
         assertEq(uint256(reads[0]), uint256(IMPLEMENTATION_STORAGE_SLOT) + 3);
         current = vm.load(address(dispatcher), bytes32(reads[0]));
         assertEq(uint8(uint256(current) >> 160), _castBoolToUInt8(flag_));
 
         /**
-         * | Name                                     | Type    | Slot                            | Offset | Bytes |
-         * |------------------------------------------|---------|---------------------------------|--------|-------|
-         * | ImplementationState.implementationState5 | address | IMPLEMENTATION_STORAGE_SLOT + 4 | 0      | 32    |
+         * | Name                                         | Type    | Slot                            | Offset | Bytes |
+         * |----------------------------------------------|---------|---------------------------------|--------|-------|
+         * | ImplementationStorage.implementationStorage5 | address | IMPLEMENTATION_STORAGE_SLOT + 4 | 0      | 32    |
          */
         vm.record();
-        dispatcher.getImplementationState5(target_);
+        dispatcher.getImplementationStorage5(target_);
         (reads, ) = vm.accesses(address(dispatcher));
         assertEq((reads[0]), keccak256(abi.encode(target_, uint256(IMPLEMENTATION_STORAGE_SLOT) + 4)));
         current = vm.load(address(dispatcher), bytes32(reads[0]));
         assertEq(uint256(current), number_);
 
         /**
-         * | Name                       | Type    | Slot                            | Offset | Bytes |
-         * |----------------------------|---------|---------------------------------|--------|-------|
-         * | ImplementationState.tokens | address | IMPLEMENTATION_STORAGE_SLOT + 5 | 0      | 32    |
+         * | Name                         | Type    | Slot                            | Offset | Bytes |
+         * |------------------------------|---------|---------------------------------|--------|-------|
+         * | ImplementationStorage.tokens | address | IMPLEMENTATION_STORAGE_SLOT + 5 | 0      | 32    |
          */
         vm.record();
         dispatcher.getToken(tokenA_, address(dispatcher));

--- a/test/ImplementationStorage.t.sol
+++ b/test/ImplementationStorage.t.sol
@@ -14,7 +14,7 @@ import {ImplementationFixture} from "./fixtures/ImplementationFixture.sol";
 import {MockImplementationModule} from "./mocks/MockImplementationModule.sol";
 
 /**
- * @title Implementation State Test
+ * @title Implementation Storage Test
  */
 contract ImplementationStorageTest is ImplementationFixture {
     // =========

--- a/test/ReflexBatch.t.sol
+++ b/test/ReflexBatch.t.sol
@@ -10,7 +10,7 @@ import {ReflexFixture} from "./fixtures/ReflexFixture.sol";
 
 // Mocks
 import {ImplementationERC20} from "./mocks/abstracts/ImplementationERC20.sol";
-import {ImplementationState} from "./mocks/abstracts/ImplementationState.sol";
+import {ImplementationStorage} from "./mocks/abstracts/ImplementationStorage.sol";
 import {MockImplementationERC20} from "./mocks/MockImplementationERC20.sol";
 import {MockImplementationERC20Hub} from "./mocks/MockImplementationERC20Hub.sol";
 import {MockImplementationModule} from "./mocks/MockImplementationModule.sol";
@@ -182,13 +182,13 @@ contract ReflexBatchTest is ReflexFixture {
         actions[0] = IReflexBatch.BatchAction({
             allowFailure: false,
             endpointAddress: address(singleModuleEndpoint),
-            callData: abi.encodeCall(ImplementationState.setImplementationState0, (message_))
+            callData: abi.encodeCall(ImplementationStorage.setImplementationStorage0, (message_))
         });
 
         actions[1] = IReflexBatch.BatchAction({
             allowFailure: false,
             endpointAddress: address(singleModuleEndpoint),
-            callData: abi.encodeCall(ImplementationState.getImplementationState0, ())
+            callData: abi.encodeCall(ImplementationStorage.getImplementationStorage0, ())
         });
 
         actions[2] = IReflexBatch.BatchAction({
@@ -272,13 +272,13 @@ contract ReflexBatchTest is ReflexFixture {
         actions[0] = IReflexBatch.BatchAction({
             allowFailure: false,
             endpointAddress: address(singleModuleEndpoint),
-            callData: abi.encodeCall(ImplementationState.setImplementationState0, (message_))
+            callData: abi.encodeCall(ImplementationStorage.setImplementationStorage0, (message_))
         });
 
         actions[1] = IReflexBatch.BatchAction({
             allowFailure: false,
             endpointAddress: address(singleModuleEndpoint),
-            callData: abi.encodeCall(ImplementationState.getImplementationState0, ())
+            callData: abi.encodeCall(ImplementationStorage.getImplementationStorage0, ())
         });
 
         actions[2] = IReflexBatch.BatchAction({
@@ -331,13 +331,13 @@ contract ReflexBatchTest is ReflexFixture {
         actions[0] = IReflexBatch.BatchAction({
             allowFailure: false,
             endpointAddress: address(singleModuleEndpoint),
-            callData: abi.encodeCall(ImplementationState.setImplementationState0, (message_))
+            callData: abi.encodeCall(ImplementationStorage.setImplementationStorage0, (message_))
         });
 
         actions[1] = IReflexBatch.BatchAction({
             allowFailure: true,
             endpointAddress: address(batchEndpoint),
-            callData: abi.encodeCall(ImplementationState.getImplementationState0, ())
+            callData: abi.encodeCall(ImplementationStorage.getImplementationStorage0, ())
         });
 
         actions[2] = IReflexBatch.BatchAction({
@@ -355,13 +355,13 @@ contract ReflexBatchTest is ReflexFixture {
         actions[0] = IReflexBatch.BatchAction({
             allowFailure: false,
             endpointAddress: address(singleModuleEndpoint),
-            callData: abi.encodeCall(ImplementationState.setImplementationState0, (bytes32("777")))
+            callData: abi.encodeCall(ImplementationStorage.setImplementationStorage0, (bytes32("777")))
         });
 
         actions[1] = IReflexBatch.BatchAction({
             allowFailure: false,
             endpointAddress: address(batchEndpoint),
-            callData: abi.encodeCall(ImplementationState.getImplementationState0, ())
+            callData: abi.encodeCall(ImplementationStorage.getImplementationStorage0, ())
         });
 
         vm.expectRevert(IReflexModule.EmptyError.selector);
@@ -374,13 +374,13 @@ contract ReflexBatchTest is ReflexFixture {
         actions[0] = IReflexBatch.BatchAction({
             allowFailure: false,
             endpointAddress: address(singleModuleEndpoint),
-            callData: abi.encodeCall(ImplementationState.setImplementationState0, (bytes32("777")))
+            callData: abi.encodeCall(ImplementationStorage.setImplementationStorage0, (bytes32("777")))
         });
 
         actions[1] = IReflexBatch.BatchAction({
             allowFailure: true,
             endpointAddress: address(0),
-            callData: abi.encodeCall(ImplementationState.getImplementationState0, ())
+            callData: abi.encodeCall(ImplementationStorage.getImplementationStorage0, ())
         });
 
         vm.expectRevert(IReflexModule.ModuleIdInvalid.selector);
@@ -393,13 +393,13 @@ contract ReflexBatchTest is ReflexFixture {
         actions[0] = IReflexBatch.BatchAction({
             allowFailure: false,
             endpointAddress: address(singleModuleEndpoint),
-            callData: abi.encodeCall(ImplementationState.setImplementationState0, (bytes32("777")))
+            callData: abi.encodeCall(ImplementationStorage.setImplementationStorage0, (bytes32("777")))
         });
 
         actions[1] = IReflexBatch.BatchAction({
             allowFailure: true,
             endpointAddress: address(internalModule),
-            callData: abi.encodeCall(ImplementationState.getImplementationState0, ())
+            callData: abi.encodeCall(ImplementationStorage.getImplementationStorage0, ())
         });
 
         vm.expectRevert(IReflexModule.ModuleIdInvalid.selector);
@@ -432,13 +432,13 @@ contract ReflexBatchTest is ReflexFixture {
         actions[0] = IReflexBatch.BatchAction({
             allowFailure: false,
             endpointAddress: address(singleModuleEndpoint),
-            callData: abi.encodeCall(ImplementationState.setImplementationState0, (bytes32("777")))
+            callData: abi.encodeCall(ImplementationStorage.setImplementationStorage0, (bytes32("777")))
         });
 
         actions[1] = IReflexBatch.BatchAction({
             allowFailure: true,
             endpointAddress: address(multiModuleEndpointC),
-            callData: abi.encodeCall(ImplementationState.getImplementationState0, ())
+            callData: abi.encodeCall(ImplementationStorage.getImplementationStorage0, ())
         });
 
         // Expect that an unregistered multi-module implementation throws an error.

--- a/test/mocks/MockImplementationDispatcher.sol
+++ b/test/mocks/MockImplementationDispatcher.sol
@@ -5,12 +5,12 @@ pragma solidity ^0.8.13;
 import {ReflexDispatcher} from "../../src/ReflexDispatcher.sol";
 
 // Mocks
-import {ImplementationState} from "./abstracts/ImplementationState.sol";
+import {ImplementationStorage} from "./abstracts/ImplementationStorage.sol";
 
 /**
  * @title Mock Implementation Dispatcher
  */
-contract MockImplementationDispatcher is ReflexDispatcher, ImplementationState {
+contract MockImplementationDispatcher is ReflexDispatcher, ImplementationStorage {
     // ===========
     // Constructor
     // ===========

--- a/test/mocks/MockImplementationMaliciousStorageModule.sol
+++ b/test/mocks/MockImplementationMaliciousStorageModule.sol
@@ -6,7 +6,7 @@ import {MockReflexModule} from "./MockReflexModule.sol";
 
 /**
  * @title Mock Implementation Malicious Storage Module
- * @dev Example of a module which incorrectly implements storage by overriding `ImplementationState`.
+ * @dev Example of a module which incorrectly implements storage by overriding `ImplementationStorage`.
  * @dev Instead it implements storage directly in the module.
  */
 contract MockImplementationMaliciousStorageModule is MockReflexModule {
@@ -43,12 +43,12 @@ contract MockImplementationMaliciousStorageModule is MockReflexModule {
     // Test stubs
     // ==========
 
-    function setMaliciousImplementationState0(bytes32 message_) public {
-        _MALICIOUS_IMPLEMENTATION_STORAGE().implementationState0 = message_;
+    function setMaliciousImplementationStorage0(bytes32 message_) public {
+        _MALICIOUS_IMPLEMENTATION_STORAGE().implementationStorage0 = message_;
     }
 
-    function getMaliciousImplementationState0() public view returns (bytes32) {
-        return _MALICIOUS_IMPLEMENTATION_STORAGE().implementationState0;
+    function getMaliciousImplementationStorage0() public view returns (bytes32) {
+        return _MALICIOUS_IMPLEMENTATION_STORAGE().implementationStorage0;
     }
 
     // =======
@@ -58,11 +58,11 @@ contract MockImplementationMaliciousStorageModule is MockReflexModule {
     /**
      * @dev Append-only extendable.
      */
-    struct MaliciousImplementationStorage {
+    struct MaliciousImplementationStorageLayout {
         /**
          * @notice Implementation state 0.
          */
-        bytes32 implementationState0;
+        bytes32 implementationStorage0;
     }
 
     // ================
@@ -76,7 +76,7 @@ contract MockImplementationMaliciousStorageModule is MockReflexModule {
     function _MALICIOUS_IMPLEMENTATION_STORAGE()
         internal
         pure
-        returns (MaliciousImplementationStorage storage storage_)
+        returns (MaliciousImplementationStorageLayout storage storage_)
     {
         assembly ("memory-safe") {
             /**

--- a/test/mocks/MockImplementationMaliciousStorageModule.sol
+++ b/test/mocks/MockImplementationMaliciousStorageModule.sol
@@ -60,7 +60,7 @@ contract MockImplementationMaliciousStorageModule is MockReflexModule {
      */
     struct MaliciousImplementationStorageLayout {
         /**
-         * @notice Implementation state 0.
+         * @notice Implementation storage 0.
          */
         bytes32 implementationStorage0;
     }

--- a/test/mocks/MockImplementationModule.sol
+++ b/test/mocks/MockImplementationModule.sol
@@ -2,13 +2,13 @@
 pragma solidity ^0.8.13;
 
 // Mocks
-import {ImplementationState} from "./abstracts/ImplementationState.sol";
+import {ImplementationStorage} from "./abstracts/ImplementationStorage.sol";
 import {MockReflexModule} from "./MockReflexModule.sol";
 
 /**
  * @title Mock Implementation Module
  */
-contract MockImplementationModule is MockReflexModule, ImplementationState {
+contract MockImplementationModule is MockReflexModule, ImplementationStorage {
     // ===========
     // Constructor
     // ===========

--- a/test/mocks/abstracts/ImplementationStorage.sol
+++ b/test/mocks/abstracts/ImplementationStorage.sol
@@ -43,27 +43,27 @@ abstract contract ImplementationStorage is ReflexStorage {
      */
     struct ImplementationStorageLayout {
         /**
-         * @notice Implementation state 0.
+         * @notice Implementation storage 0.
          */
         bytes32 implementationStorage0;
         /**
-         * @notice Implementation state 1.
+         * @notice Implementation storage 1.
          */
         uint256 implementationStorage1;
         /**
-         * @notice Implementation state 2.
+         * @notice Implementation storage 2.
          */
         address implementationStorage2;
         /**
-         * @notice Implementation state 3.
+         * @notice Implementation storage 3.
          */
         address implementationStorage3;
         /**
-         * @notice Implementation state 4.
+         * @notice Implementation storage 4.
          */
         bool implementationStorage4;
         /**
-         * @notice Implementation state 5.
+         * @notice Implementation storage 5.
          */
         mapping(address => uint256) implementationStorage5;
         /**
@@ -78,7 +78,7 @@ abstract contract ImplementationStorage is ReflexStorage {
 
     /**
      * @dev Get the Implementation storage pointer.
-     * @return storage_ Pointer to the Implementation storage state.
+     * @return storage_ Pointer to the Implementation storage slot.
      */
     // solhint-disable-next-line func-name-mixedcase
     function _IMPLEMENTATION_STORAGE() internal pure returns (ImplementationStorageLayout storage storage_) {

--- a/test/mocks/abstracts/ImplementationStorage.sol
+++ b/test/mocks/abstracts/ImplementationStorage.sol
@@ -2,12 +2,12 @@
 pragma solidity ^0.8.13;
 
 // Sources
-import {ReflexState} from "../../../src/ReflexState.sol";
+import {ReflexStorage} from "../../../src/ReflexStorage.sol";
 
 /**
- * @title Implementation State
+ * @title Implementation Storage
  */
-abstract contract ImplementationState is ReflexState {
+abstract contract ImplementationStorage is ReflexStorage {
     // =========
     // Constants
     // =========
@@ -41,31 +41,31 @@ abstract contract ImplementationState is ReflexState {
     /**
      * @dev Append-only extendable.
      */
-    struct ImplementationStorage {
+    struct ImplementationStorageLayout {
         /**
          * @notice Implementation state 0.
          */
-        bytes32 implementationState0;
+        bytes32 implementationStorage0;
         /**
          * @notice Implementation state 1.
          */
-        uint256 implementationState1;
+        uint256 implementationStorage1;
         /**
          * @notice Implementation state 2.
          */
-        address implementationState2;
+        address implementationStorage2;
         /**
          * @notice Implementation state 3.
          */
-        address implementationState3;
+        address implementationStorage3;
         /**
          * @notice Implementation state 4.
          */
-        bool implementationState4;
+        bool implementationStorage4;
         /**
          * @notice Implementation state 5.
          */
-        mapping(address => uint256) implementationState5;
+        mapping(address => uint256) implementationStorage5;
         /**
          * @notice Token mapping.
          */
@@ -81,7 +81,7 @@ abstract contract ImplementationState is ReflexState {
      * @return storage_ Pointer to the Implementation storage state.
      */
     // solhint-disable-next-line func-name-mixedcase
-    function _IMPLEMENTATION_STORAGE() internal pure returns (ImplementationStorage storage storage_) {
+    function _IMPLEMENTATION_STORAGE() internal pure returns (ImplementationStorageLayout storage storage_) {
         assembly ("memory-safe") {
             storage_.slot := _IMPLEMENTATION_STORAGE_SLOT
         }
@@ -96,27 +96,27 @@ abstract contract ImplementationState is ReflexState {
         return _REFLEX_STORAGE_SLOT;
     }
 
-    function getReflexState0() public view returns (uint256) {
+    function getReflexStorage0() public view returns (uint256) {
         return _REFLEX_STORAGE().reentrancyStatus;
     }
 
-    function getReflexState1() public view returns (address) {
+    function getReflexStorage1() public view returns (address) {
         return _REFLEX_STORAGE().owner;
     }
 
-    function getReflexState2() public view returns (address) {
+    function getReflexStorage2() public view returns (address) {
         return _REFLEX_STORAGE().pendingOwner;
     }
 
-    function getReflexState3(uint32 moduleId_) public view returns (address) {
+    function getReflexStorage3(uint32 moduleId_) public view returns (address) {
         return _REFLEX_STORAGE().modules[moduleId_];
     }
 
-    function getReflexState4(uint32 moduleId_) public view returns (address) {
+    function getReflexStorage4(uint32 moduleId_) public view returns (address) {
         return _REFLEX_STORAGE().endpoints[moduleId_];
     }
 
-    function getReflexState5(address endpoint_) public view returns (TrustRelation memory) {
+    function getReflexStorage5(address endpoint_) public view returns (TrustRelation memory) {
         return _REFLEX_STORAGE().relations[endpoint_];
     }
 
@@ -129,52 +129,52 @@ abstract contract ImplementationState is ReflexState {
         return _IMPLEMENTATION_STORAGE_SLOT;
     }
 
-    function getImplementationState0() public view returns (bytes32) {
-        return _IMPLEMENTATION_STORAGE().implementationState0;
+    function getImplementationStorage0() public view returns (bytes32) {
+        return _IMPLEMENTATION_STORAGE().implementationStorage0;
     }
 
-    function getImplementationState1() public view returns (uint256) {
-        return _IMPLEMENTATION_STORAGE().implementationState1;
+    function getImplementationStorage1() public view returns (uint256) {
+        return _IMPLEMENTATION_STORAGE().implementationStorage1;
     }
 
-    function getImplementationState2() public view returns (address) {
-        return _IMPLEMENTATION_STORAGE().implementationState2;
+    function getImplementationStorage2() public view returns (address) {
+        return _IMPLEMENTATION_STORAGE().implementationStorage2;
     }
 
-    function getImplementationState3() public view returns (address) {
-        return _IMPLEMENTATION_STORAGE().implementationState3;
+    function getImplementationStorage3() public view returns (address) {
+        return _IMPLEMENTATION_STORAGE().implementationStorage3;
     }
 
-    function getImplementationState4() public view returns (bool) {
-        return _IMPLEMENTATION_STORAGE().implementationState4;
+    function getImplementationStorage4() public view returns (bool) {
+        return _IMPLEMENTATION_STORAGE().implementationStorage4;
     }
 
-    function getImplementationState5(address target_) public view returns (uint256) {
-        return _IMPLEMENTATION_STORAGE().implementationState5[target_];
+    function getImplementationStorage5(address target_) public view returns (uint256) {
+        return _IMPLEMENTATION_STORAGE().implementationStorage5[target_];
     }
 
-    function setImplementationState0(bytes32 message_) public {
-        _IMPLEMENTATION_STORAGE().implementationState0 = message_;
+    function setImplementationStorage0(bytes32 message_) public {
+        _IMPLEMENTATION_STORAGE().implementationStorage0 = message_;
     }
 
-    function setImplementationState1(uint256 number_) public {
-        _IMPLEMENTATION_STORAGE().implementationState1 = number_;
+    function setImplementationStorage1(uint256 number_) public {
+        _IMPLEMENTATION_STORAGE().implementationStorage1 = number_;
     }
 
-    function setImplementationState2(address target_) public {
-        _IMPLEMENTATION_STORAGE().implementationState2 = target_;
+    function setImplementationStorage2(address target_) public {
+        _IMPLEMENTATION_STORAGE().implementationStorage2 = target_;
     }
 
-    function setImplementationState3(address target_) public {
-        _IMPLEMENTATION_STORAGE().implementationState3 = target_;
+    function setImplementationStorage3(address target_) public {
+        _IMPLEMENTATION_STORAGE().implementationStorage3 = target_;
     }
 
-    function setImplementationState4(bool flag_) public {
-        _IMPLEMENTATION_STORAGE().implementationState4 = flag_;
+    function setImplementationStorage4(bool flag_) public {
+        _IMPLEMENTATION_STORAGE().implementationStorage4 = flag_;
     }
 
-    function setImplementationState5(address target_, uint256 number_) public {
-        _IMPLEMENTATION_STORAGE().implementationState5[target_] = number_;
+    function setImplementationStorage5(address target_, uint256 number_) public {
+        _IMPLEMENTATION_STORAGE().implementationStorage5[target_] = number_;
     }
 
     function getToken(
@@ -192,7 +192,7 @@ abstract contract ImplementationState is ReflexState {
         balanceOf_ = _IMPLEMENTATION_STORAGE().tokens[token_].balanceOf[user_];
     }
 
-    function setImplementationState(
+    function setImplementationStorage(
         bytes32 message_,
         uint256 number_,
         address target_,
@@ -200,17 +200,12 @@ abstract contract ImplementationState is ReflexState {
         address tokenA_,
         address tokenB_
     ) public {
-        _IMPLEMENTATION_STORAGE().implementationState0 = message_;
-
-        _IMPLEMENTATION_STORAGE().implementationState1 = number_;
-
-        _IMPLEMENTATION_STORAGE().implementationState2 = target_;
-
-        _IMPLEMENTATION_STORAGE().implementationState3 = target_;
-
-        _IMPLEMENTATION_STORAGE().implementationState4 = flag_;
-
-        _IMPLEMENTATION_STORAGE().implementationState5[target_] = number_;
+        _IMPLEMENTATION_STORAGE().implementationStorage0 = message_;
+        _IMPLEMENTATION_STORAGE().implementationStorage1 = number_;
+        _IMPLEMENTATION_STORAGE().implementationStorage2 = target_;
+        _IMPLEMENTATION_STORAGE().implementationStorage3 = target_;
+        _IMPLEMENTATION_STORAGE().implementationStorage4 = flag_;
+        _IMPLEMENTATION_STORAGE().implementationStorage5[target_] = number_;
 
         _IMPLEMENTATION_STORAGE().tokens[tokenA_].name = "Token A";
         _IMPLEMENTATION_STORAGE().tokens[tokenA_].symbol = "TKNA";


### PR DESCRIPTION
In order to not clash with the struct naming, the structs are postfixed by `Layout`.

Closes: #124 

Please note that these changes will be breaking upstream but should be relatively easy to fix.